### PR TITLE
Upgrade to Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
   </issueManagement>
 
   <properties>
-    <java.version>1.7</java.version>
+    <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 


### PR DESCRIPTION
There are some features that I would like to introduce in a future PR that is made a great deal easier through an upgrade to Java 1.8. Is there a hard blocker on this upgrade?

I was able to compile and use this driver with 1.8