### PR TITLE
Set scope=provided

### DIFF
--- a/opentracing-elasticsearch-client-common/pom.xml
+++ b/opentracing-elasticsearch-client-common/pom.xml
@@ -33,6 +33,7 @@
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>transport</artifactId>
       <version>${elasticsearch5.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/opentracing-elasticsearch5-client/pom.xml
+++ b/opentracing-elasticsearch5-client/pom.xml
@@ -39,6 +39,7 @@
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>transport</artifactId>
       <version>${elasticsearch5.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/opentracing-elasticsearch6-client/pom.xml
+++ b/opentracing-elasticsearch6-client/pom.xml
@@ -33,18 +33,13 @@
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-elasticsearch-client-common</artifactId>
       <version>0.1.5-SNAPSHOT</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.elasticsearch.client</groupId>
-          <artifactId>transport</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>transport</artifactId>
       <version>${elasticsearch6.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/opentracing-elasticsearch7-client/pom.xml
+++ b/opentracing-elasticsearch7-client/pom.xml
@@ -31,17 +31,12 @@
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-elasticsearch-client-common</artifactId>
       <version>0.1.5-SNAPSHOT</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.elasticsearch.client</groupId>
-          <artifactId>transport</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>transport</artifactId>
       <version>${elasticsearch7.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Setting the scope of the target libraries of instrumentation to "provided". It is a guarantee that the integrating codebase will provide these libraries, otherwise the instrumentation plugin would be moot if the codebase does not already have these libraries.